### PR TITLE
Addon - Audio Link Controller Lock via TXL AccessControl

### DIFF
--- a/Packages/com.texelsaur.access/Runtime/Scripts/Addon/Editor.meta
+++ b/Packages/com.texelsaur.access/Runtime/Scripts/Addon/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de1689d4b85447149869cfe2efc90991
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.texelsaur.access/Runtime/Scripts/Addon/Editor/TXLAudioLinkLockBuildDetect.cs
+++ b/Packages/com.texelsaur.access/Runtime/Scripts/Addon/Editor/TXLAudioLinkLockBuildDetect.cs
@@ -1,0 +1,139 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.Build.Reporting;
+using UnityEditor.Build;
+using System.Collections.Generic;
+using VRC;
+
+namespace DrakenStark
+{
+    [InitializeOnLoad]
+    public class TXLAudioLinkLockBuildDetect : Object, IProcessSceneWithReport
+    {
+        //Regardless of multiple copies in the scene, On Build and Mode change, this should in theory only be run once.
+        //Go through everything that needs to be done in either in this class without worrying about doubled effort.
+
+        //Detect Build before entering Play Mode
+        static TXLAudioLinkLockBuildDetect()
+        {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            //Changes will persist after exiting Play mode.
+            if (state == PlayModeStateChange.ExitingEditMode)
+            {
+                //Debug.LogWarning("Play Build Process Detected!");
+                _finalizeForBuild();
+            }
+
+            //Changes will revert after exiting Play mode.
+            if (state == PlayModeStateChange.EnteredPlayMode)
+            {
+            }
+        }
+
+        //Detect Build when not entering Play Mode
+        public int callbackOrder => 0; //Lets Unity know that, during a build, this script will care where it falls in the order of scripts to run.
+        //public int callbackOrder { get; } //Lets Unity know that, during a build, this script will not care where it falls in the order of scripts to run.
+        public void OnProcessScene(UnityEngine.SceneManagement.Scene scene, BuildReport report)
+        {
+            if (!Application.isPlaying)
+            {
+                //Debug.LogWarning("Non-Play Build Process Detected!");
+                _finalizeForBuild();
+            }
+        }
+
+        //Code to run in either Build case
+        public static void _finalizeForBuild()
+        {
+            //Debug.LogWarning("Build Prep Started!");
+
+            TXLAudioLinkLock[] allTXLAudioLinkLocks = FindObjectsOfType<TXLAudioLinkLock>();
+            AudioLink.AudioLinkController[] aLControllerList = null;
+            List<VRC.SDK3.Components.VRCPickup> allPickups = new List<VRC.SDK3.Components.VRCPickup>();
+            List<UnityEngine.UI.Button> allButtons = new List<UnityEngine.UI.Button>();
+            List<UnityEngine.UI.Slider> allSliders = new List<UnityEngine.UI.Slider>();
+            List<UnityEngine.UI.Toggle> allToggles = new List<UnityEngine.UI.Toggle>();
+
+            //Go through each of the TXLAudioLinkLock scripts in the scene.
+            for (int tXLAudioLinkLock = 0; tXLAudioLinkLock < allTXLAudioLinkLocks.Length; tXLAudioLinkLock++)
+            {
+                try
+                {
+                    //For each Audio Link Controller, find all the appropriate objects and populate each of the arrays in the Editor so Players will not have to.
+                    aLControllerList = (AudioLink.AudioLinkController[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_audioLinkControllers");
+                    Debug.LogWarning("There are " + aLControllerList.Length + " Audio Link Controllers detected on " + allTXLAudioLinkLocks[tXLAudioLinkLock].name, allTXLAudioLinkLocks[tXLAudioLinkLock].gameObject);
+                    if (VRC.SDKBase.Utilities.IsValid(aLControllerList) && aLControllerList.Length > 0)
+                    {
+                        //Set all of the list variables to an empty default.
+                        allPickups = new List<VRC.SDK3.Components.VRCPickup>();
+                        allButtons = new List<UnityEngine.UI.Button>();
+                        allSliders = new List<UnityEngine.UI.Slider>();
+                        allToggles = new List<UnityEngine.UI.Toggle>();
+
+                        //Use the list variables to collect all the components.
+                        for (int aLController = 0; aLController < aLControllerList.Length; aLController++)
+                        {
+                            allPickups.AddRange(aLControllerList[aLController].gameObject.GetComponentsInChildren<VRC.SDK3.Components.VRCPickup>(true));
+                            allButtons.AddRange(aLControllerList[aLController].gameObject.GetComponentsInChildren<UnityEngine.UI.Button>(true));
+                            allSliders.AddRange(aLControllerList[aLController].gameObject.GetComponentsInChildren<UnityEngine.UI.Slider>(true));
+                            allToggles.AddRange(aLControllerList[aLController].gameObject.GetComponentsInChildren<UnityEngine.UI.Toggle>(true));
+                        }
+
+                        //Lock down all the found components and Mark them to have the change saved.
+                        for (int pickup = 0; pickup < allPickups.Count; pickup++)
+                        {
+                            allPickups[pickup].pickupable = false;
+                            allPickups[pickup].MarkDirty();
+                        }
+                        for (int uIElement = 0; uIElement < allButtons.Count; uIElement++)
+                        {
+                            allButtons[uIElement].interactable = false;
+                            allButtons[uIElement].MarkDirty();
+                        }
+                        for (int uIElement = 0; uIElement < allSliders.Count; uIElement++)
+                        {
+                            allSliders[uIElement].interactable = false;
+                            allSliders[uIElement].MarkDirty();
+                        }
+                        for (int uIElement = 0; uIElement < allToggles.Count; uIElement++)
+                        {
+                            allToggles[uIElement].interactable = false;
+                            allToggles[uIElement].MarkDirty();
+                        }
+
+                        //Update the script variables with the lists of collected components.
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_vRCPickups", allPickups.ToArray());
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_buttons", allButtons.ToArray());
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_sliders", allSliders.ToArray());
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_toggles", allToggles.ToArray());
+
+                        //Checks if the array is a valid variable, then checks if it has a length larger than zero. If not, the variable is set to false thanks to the check returning a bool value.
+                        //If AudioLink ever updates in a way that it doesn't have one of these kinds of UI elements, the rest can still be found and allow the runtime script to still work.
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_hasPickups", VRC.SDKBase.Utilities.IsValid((VRC.SDK3.Components.VRCPickup[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_vRCPickups")) && ((VRC.SDK3.Components.VRCPickup[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_vRCPickups")).Length > 0);
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_hasButtons", VRC.SDKBase.Utilities.IsValid((UnityEngine.UI.Button[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_buttons")) && ((UnityEngine.UI.Button[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_buttons")).Length > 0);
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_hasSliders", VRC.SDKBase.Utilities.IsValid((UnityEngine.UI.Slider[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_sliders")) && ((UnityEngine.UI.Slider[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_sliders")).Length > 0);
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].SetProgramVariable("_hasToggles", VRC.SDKBase.Utilities.IsValid((UnityEngine.UI.Toggle[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_toggles")) && ((UnityEngine.UI.Toggle[])allTXLAudioLinkLocks[tXLAudioLinkLock].GetProgramVariable("_toggles")).Length > 0);
+
+                        //Mark the script so that changes are saved.
+                        allTXLAudioLinkLocks[tXLAudioLinkLock].MarkDirty();
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    Debug.LogException(ex, allTXLAudioLinkLocks[tXLAudioLinkLock].gameObject);
+                }
+            }
+
+            //Update the AssetDatabase so the new screenshot file(s) can be recognized.
+            //Resources.UnloadUnusedAssets();
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            //Debug.LogWarning("Build Prep Finished!");
+        }
+    }
+}

--- a/Packages/com.texelsaur.access/Runtime/Scripts/Addon/Editor/TXLAudioLinkLockBuildDetect.cs.meta
+++ b/Packages/com.texelsaur.access/Runtime/Scripts/Addon/Editor/TXLAudioLinkLockBuildDetect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87356a641238a824189363baa8b3ab60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.asset
+++ b/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.asset
@@ -1,0 +1,695 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: TXLAudioLinkLock
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 3fcbb004b96d34b4baad5e7ebdd797d4,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: 498e7d16ef5d53844bc6a7144f585a5c, type: 3}
+  scriptVersion: 2
+  compiledVersion: 2
+  behaviourSyncMode: 1
+  hasInteractEvent: 0
+  scriptID: -8176956716477258093
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 10
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _accessControl
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _accessControl
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Texel.AccessControl, com.texelsaur.common
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 4|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.Udon.UdonBehaviour, VRC.Udon
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 5|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 6|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _audioLinkControllers
+    - Name: $v
+      Entry: 7
+      Data: 7|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _audioLinkControllers
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 8|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: AudioLink.AudioLinkController[], AudioLink
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 7
+      Data: 9|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Component[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 10|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 11|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _vRCPickups
+    - Name: $v
+      Entry: 7
+      Data: 12|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _vRCPickups
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 13|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.SDK3.Components.VRCPickup[], VRCSDK3
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 13
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 14|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 15|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 16|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _hasPickups
+    - Name: $v
+      Entry: 7
+      Data: 17|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _hasPickups
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 18|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Boolean, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 19|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 20|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 21|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _buttons
+    - Name: $v
+      Entry: 7
+      Data: 22|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _buttons
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 23|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Button[], UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 23
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 25|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 26|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _hasButtons
+    - Name: $v
+      Entry: 7
+      Data: 27|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _hasButtons
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 29|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 30|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _sliders
+    - Name: $v
+      Entry: 7
+      Data: 31|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _sliders
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 32|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Slider[], UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 32
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 33|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 34|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 35|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _hasSliders
+    - Name: $v
+      Entry: 7
+      Data: 36|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _hasSliders
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 37|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 38|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 39|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _toggles
+    - Name: $v
+      Entry: 7
+      Data: 40|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _toggles
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 41|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.UI.Toggle[], UnityEngine.UI
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 41
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 42|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 43|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 44|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: _hasToggles
+    - Name: $v
+      Entry: 7
+      Data: 45|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: _hasToggles
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 46|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 47|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 48|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.asset.meta
+++ b/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2499861f6114a8c4aa9c80d19d156e60
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.cs
+++ b/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.cs
@@ -1,0 +1,67 @@
+using UdonSharp;
+using UnityEngine;
+
+namespace DrakenStark
+{
+    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+    public class TXLAudioLinkLock : UdonSharpBehaviour
+    {
+        [SerializeField] private Texel.AccessControl _accessControl = null;
+        [SerializeField] private AudioLink.AudioLinkController[] _audioLinkControllers = new AudioLink.AudioLinkController[0];
+
+        [SerializeField, HideInInspector] private VRC.SDK3.Components.VRCPickup[] _vRCPickups = new VRC.SDK3.Components.VRCPickup[0];
+        [SerializeField, HideInInspector] private bool _hasPickups = false;
+        [SerializeField, HideInInspector] private UnityEngine.UI.Button[] _buttons = new UnityEngine.UI.Button[0];
+        [SerializeField, HideInInspector] private bool _hasButtons = false;
+        [SerializeField, HideInInspector] private UnityEngine.UI.Slider[] _sliders = new UnityEngine.UI.Slider[0];
+        [SerializeField, HideInInspector] private bool _hasSliders = false;
+        [SerializeField, HideInInspector] private UnityEngine.UI.Toggle[] _toggles = new UnityEngine.UI.Toggle[0];
+        [SerializeField, HideInInspector] private bool _hasToggles = false;
+
+        private void Start()
+        {
+            SendCustomEventDelayedFrames(nameof(_lateStart), 1);
+        }
+
+        public void _lateStart()
+        {
+            _accessControl._Register(Texel.AccessControl.EVENT_VALIDATE, this, nameof(checkAccess));
+            checkAccess();
+        }
+
+        public void checkAccess()
+        {
+            if (_accessControl._LocalHasAccess())
+            {
+                if (_hasPickups)
+                {
+                    for (int i = 0; i < _vRCPickups.Length; i++)
+                    {
+                        _vRCPickups[i].pickupable = true;
+                    }
+                }
+                if (_hasButtons)
+                {
+                    for (int i = 0; i < _buttons.Length; i++)
+                    {
+                        _buttons[i].interactable = true;
+                    }
+                }
+                if (_hasSliders)
+                {
+                    for (int i = 0; i < _sliders.Length; i++)
+                    {
+                        _sliders[i].interactable = true;
+                    }
+                }
+                if (!_hasToggles)
+                {
+                    for (int i = 0; i < _toggles.Length; i++)
+                    {
+                        _toggles[i].interactable = true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.cs.meta
+++ b/Packages/com.texelsaur.access/Runtime/Scripts/Addon/TXLAudioLinkLock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 498e7d16ef5d53844bc6a7144f585a5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Edits linked Audio Link Controllers to lock all interactable UI Elements and VRCPickups on Build or by starting Play Mode. Defaults the Audio Link Controller(s) to be locked down upon loading the world in-game. Once loaded, AccessControl is checked and event registered to allow the local player to interact and/or pickup the Audio Link Controller(s).